### PR TITLE
Fix ports in docker for orchestrator

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -2,3 +2,7 @@ services:
   place-wrapper:
     ports:
       - "8080:8080"
+  place_wrapper_cache:
+    ports:
+      - "6379:6379"
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,14 +11,12 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - redis
+      - place_wrapper_cache
 
-  redis:
+  place_wrapper_cache:
     image: "redis:alpine"
-    container_name: redis_cache
+    container_name: places_wrapper_cache
     restart: always
-    ports:
-      - "6379:6379"
     volumes:
       - redis_data:/data
 


### PR DESCRIPTION
This pull request includes changes to the `docker-compose` configuration files to rename the `redis` service to `place_wrapper_cache` and update the corresponding dependencies and ports.

Changes to `docker-compose` configuration:

* [`docker-compose.override.yaml`](diffhunk://#diff-5cf196bb28f864c2149668ce0fc575489e4446710d79129f3d8cece2639ef6c3R5-R8): Added a new `place_wrapper_cache` service with port `6379:6379`.
* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L14-L21): Renamed the `redis` service to `place_wrapper_cache`, updated the `depends_on` section to reflect this change, and removed the ports configuration for the renamed service.