### PR TITLE
VOYAGE-49 Remove docker ports from main docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,8 +8,6 @@ services:
       - REDIS_PORT=6379
     volumes:
       - .:/app
-    ports:
-      - "8080:8080"
     depends_on:
       - place_wrapper_cache
 


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yaml` file. The change removes the port mapping for the service, which previously mapped port 8080 on the host to port 8080 on the container.

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L11-L12): Removed the `ports` section that mapped port 8080 on the host to port 8080 on the container.