### PR TITLE
VOYAGE-52-Fix-ports-for-cache-in-place-wrapper

### DIFF
--- a/app/services/redis_client.py
+++ b/app/services/redis_client.py
@@ -1,7 +1,7 @@
 import redis.asyncio as redis
 import os
 
-REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
+REDIS_HOST = os.getenv("REDIS_HOST", "places_wrapper_cache")
 REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
 
 class RedisClient:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,10 +4,11 @@ services:
     container_name: place-wrapper
     environment:
       - ENV_VAR=example
-      - REDIS_HOST=redis
+      - REDIS_HOST=places_wrapper_cache
       - REDIS_PORT=6379
     volumes:
       - .:/app
+      # - .:/app:Z
     depends_on:
       - place_wrapper_cache
 


### PR DESCRIPTION
This pull request includes changes to improve the configuration of the Redis client and update the `docker-compose.yaml` file accordingly. The most important changes include modifying the Redis host environment variable and updating the Docker Compose service configuration.

Configuration updates:

* [`app/services/redis_client.py`](diffhunk://#diff-fc6d897ff96e876869962efd35ca9937af1c7173d0c04172ec5f1159ed8062bdL4-R4): Changed the default value of `REDIS_HOST` from "localhost" to "places_wrapper_cache" to align with the new configuration.

Docker Compose updates:

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L7-R11): Updated the `REDIS_HOST` environment variable for the `place-wrapper` service to "places_wrapper_cache" to match the updated Redis client configuration.