### PR TITLE
VOYAGE-81-Coordinates-Bug

### DIFF
--- a/app/models/fetch_places/request_models.py
+++ b/app/models/fetch_places/request_models.py
@@ -10,6 +10,6 @@ class Location(BaseModel):
 class PlacesRequest(BaseModel):
     type: str = "place"
     location: Location
-    radius: int = 500
+    radius: int = 10000
     includedTypes: Optional[List[str]] = []
     excludedTypes: Optional[List[str]] = []


### PR DESCRIPTION
This pull request includes an important change to the `radius` attribute in the `PlacesRequest` class within the `app/models/fetch_places/request_models.py` file. The default value for `radius` has been increased from 500 to 10000.

* [`app/models/fetch_places/request_models.py`](diffhunk://#diff-a5ff3c42adb28baddf9555b89e2b5cef9ec3cd0df93d8d4ed5ffc1984be23fecL13-R13): Changed the default value of the `radius` attribute in the `PlacesRequest` class from 500 to 10000.