### PR TITLE
fix duplicates from must visit places

### DIFF
--- a/app/handlers/get_places_handler.py
+++ b/app/handlers/get_places_handler.py
@@ -117,6 +117,7 @@ def normalize_place_response(data):
         google_range=PriceRange(currency=currency,start_price=start_price,end_price=end_price).model_dump()
     return {
         "place_id": place.get("id"),
+        "id": place.get("id"),
         "name": place.get("displayName", {}).get("text"),
         "description": place.get("editorialSummary", {}).get("overview"),
         "address": place.get("formattedAddress"),


### PR DESCRIPTION
This pull request makes a minor adjustment to the `normalize_place_response` function in `app/handlers/get_places_handler.py`. The change adds a new key, `"id"`, to the response dictionary, mapping it to the `place.get("id")` value.